### PR TITLE
Fix YAML syntax errors in publications and talks

### DIFF
--- a/content/french/publications/publication-1.md
+++ b/content/french/publications/publication-1.md
@@ -1,5 +1,5 @@
 ---
-title: ""Le plus grand changement du fil d'actualité depuis 2013" : Facebook facilite le contournement de son algorithme"
+title: '"Le plus grand changement du fil d''actualité depuis 2013" : Facebook facilite le contournement de son algorithme'
 date: 2020-03-14T15:40:24+06:00
 # publication thumb
 image : "images/publications/pub1.jpg"

--- a/content/french/publications/publication-2.md
+++ b/content/french/publications/publication-2.md
@@ -1,5 +1,5 @@
 ---
-title: ""Le plus grand changement du fil d'actualité depuis 2013" : Facebook facilite le contournement de son algorithme"
+title: '"Le plus grand changement du fil d''actualité depuis 2013" : Facebook facilite le contournement de son algorithme'
 date: 2020-03-14T15:40:24+06:00
 # publication thumb
 image : "images/publications/pub2.jpg"

--- a/content/french/publications/publication-3.md
+++ b/content/french/publications/publication-3.md
@@ -1,5 +1,5 @@
 ---
-title: ""Le plus grand changement du fil d'actualité depuis 2013" : Facebook facilite le contournement de son algorithme"
+title: '"Le plus grand changement du fil d''actualité depuis 2013" : Facebook facilite le contournement de son algorithme'
 date: 2020-03-14T15:40:24+06:00
 # publication thumb
 image : "images/publications/pub3.jpg"

--- a/content/french/talks/talk-1.md
+++ b/content/french/talks/talk-1.md
@@ -1,5 +1,5 @@
 ---
-title: ""Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s'abonner" : Leçons de construction"
+title: '"Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s''abonner" : Leçons de construction'
 date: 2020-03-14T15:40:24+06:00
 # talks thumb
 image : "images/talks/talk1.jpg"

--- a/content/french/talks/talk-2.md
+++ b/content/french/talks/talk-2.md
@@ -1,5 +1,5 @@
 ---
-title: ""Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s'abonner" : Leçons de construction"
+title: '"Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s''abonner" : Leçons de construction'
 date: 2020-03-14T15:40:24+06:00
 # talks thumb
 image : "images/talks/talk2.jpg"

--- a/content/french/talks/talk-3.md
+++ b/content/french/talks/talk-3.md
@@ -1,5 +1,5 @@
 ---
-title: ""Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s'abonner" : Leçons de construction"
+title: '"Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s''abonner" : Leçons de construction'
 date: 2020-03-14T15:40:24+06:00
 # talks thumb
 image : "images/talks/talk3.jpg"

--- a/content/french/talks/talk-4.md
+++ b/content/french/talks/talk-4.md
@@ -1,5 +1,5 @@
 ---
-title: ""Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s'abonner" : Leçons de construction"
+title: '"Les utilisateurs qui visitent trois fois par semaine sont 8 fois plus susceptibles de s''abonner" : Leçons de construction'
 date: 2020-03-14T15:40:24+06:00
 # talks thumb
 image : "images/talks/talk4.jpg"


### PR DESCRIPTION
Fixed invalid YAML front matter with nested quotes in:
- All 3 publication files
- All 4 talk files

Changed from double quotes to single quotes to avoid parsing errors.